### PR TITLE
Fix leaking pool connections.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -11,18 +11,21 @@ type Cache struct {
 // Delete clears the cache value for the provided key
 func (c Cache) Delete(key string) (interface{}, error) {
     conn := c.ConnPool.Get()
+    defer conn.Close()
     return conn.Do("DEL", key)
 }
 
 // Set sets the cache value for the provided key
 func (c Cache) Set(key string, val string) (interface{}, error) {
     conn := c.ConnPool.Get()
+    defer conn.Close()
     return conn.Do("SET", key, val)
 }
 
 // Expire sets the cache value for the provided key
 func (c Cache) Expire(key string, mSeconds int) {
     conn := c.ConnPool.Get()
+    defer conn.Close()
     conn.Do("PEXPIRE", key, mSeconds)
 }
 
@@ -30,6 +33,7 @@ func (c Cache) Expire(key string, mSeconds int) {
 // Get gets the cache value for the provided key
 func (c Cache) Get(key string) (string, error) {
     conn := c.ConnPool.Get()
+    defer conn.Close()
     data, err := redis.String(conn.Do("GET", key))
     if err != nil {
         return "", err


### PR DESCRIPTION
- Minor fix for leaking connections.
- Tested with the following code:

``` Go
    cache, err := metre.NewCache("127.0.0.1:6379")
    if err != nil{
        fmt.Println("Couldn't open a connection to redis")
        return
    }

    for x :=0; x < 100; x++{
        cache.Set("ralph", "caraveo")
    }

    var s string
    fmt.Scanln(&s)
```
- Tested with: `sudo lsof -i -P | grep 6379 | grep ESTABLISHED | wc -l` before and after change to see major reduction in file handles
